### PR TITLE
Add support for multi-gpu fine-tuning

### DIFF
--- a/conf/config_eva.yaml
+++ b/conf/config_eva.yaml
@@ -15,5 +15,4 @@ logging_path: /data/UKBB/SSL/evaluations
 report_root: "/home/cxx579/ssw/reports/"
 # report_path: "${report_root}${data.dataset_name}_${evaluation.evaluation_name}_${data.subject_count}.csv"
 report_path: "${report_root}${data.dataset_name}_${evaluation.evaluation_name}_${data.subject_count}_${evaluation.subR}.csv"
-is_dist: true
 is_verbose: false

--- a/conf/config_eva.yaml
+++ b/conf/config_eva.yaml
@@ -6,6 +6,8 @@ defaults:
   - dataloader: ten_sec
 
 gpu: -1
+gpu_ids: [0, 1, 2]  # gpus to use if multi_gpu==true
+multi_gpu: false
 num_split: 5
 augmentation: true
 model_path: /data/UKBB/tmp_mdl/

--- a/downstream_task_evaluation.py
+++ b/downstream_task_evaluation.py
@@ -629,7 +629,8 @@ def load_weights(
     )  # v2 has the right para names
 
     # distributed pretraining can be inferred from the keys' module. prefix
-    if 'module.' in list(pretrained_dict_v2.keys())[0]:
+    head = next(iter(pretrained_dict_v2)).split('.')[0]  # get head of first key
+    if head == 'module':
         # remove module. prefix from dict keys
         pretrained_dict_v2 = {k.partition('module.')[2]: pretrained_dict_v2[k] for k in pretrained_dict_v2.keys()}
 

--- a/downstream_task_evaluation.py
+++ b/downstream_task_evaluation.py
@@ -293,6 +293,10 @@ def init_model(cfg, my_device):
         model = SSLNET(
             output_size=cfg.data.output_size, flatten_size=1024
         )  # VGG
+
+    if cfg.multi_gpu:
+        model = nn.DataParallel(model, device_ids=cfg.gpu_ids)
+
     model.to(my_device, dtype=torch.float)
     return model
 
@@ -632,7 +636,12 @@ def load_weights(
             new_key = ".".join(para_names[name_start_idx:])
             pretrained_dict_v2[new_key] = pretrained_dict_v2.pop(key)
 
-    model_dict = model.state_dict()
+    if hasattr(model, 'module'):
+        model_dict = model.module.state_dict()
+        multi_gpu_ft = True
+    else:
+        model_dict = model.state_dict()
+        multi_gpu_ft = False
 
     # 1. filter out unnecessary keys such as the final linear layers
     #    we don't want linear layer weights either
@@ -646,7 +655,10 @@ def load_weights(
     model_dict.update(pretrained_dict)
 
     # 3. load the new state dict
-    model.load_state_dict(model_dict)
+    if multi_gpu_ft:
+        model.module.load_state_dict(model_dict)
+    else:
+        model.load_state_dict(model_dict)
     print("%d Weights loaded" % len(pretrained_dict))
 
 
@@ -688,6 +700,8 @@ def main(cfg):
     GPU = cfg.gpu
     if GPU != -1:
         my_device = "cuda:" + str(GPU)
+    elif cfg.multi_gpu is True:
+        my_device = "cuda:0"  # use the first GPU as master
     else:
         my_device = "cpu"
     # Expected shape of downstream X and Y


### PR DESCRIPTION
Add multi-gpu fine-tuning (with `torch.nn.DataParallel`) to `downstream_task_evaluation.py`. Currently only to the SSL+MLP evaluation, other evaluations don't benefit much from multi-gpu training (DataParallel could still easily be added to the others if wanted, but I haven't tested these).

Changes:

- `load_weights` checks if the fine-tuned model is trained distributed or not (by checking `module` attrib), and loads the pretrained weights accordingly
- Infer whether the pretrained model was trained in distributed mode from the key name (if it contains 'module.' prefix it's distributed)
- Remove the `is_dist` config flag, because it's obsolete by the above change
- Remove the `name_start_idx` argument because we can just strip the prefix with str.partition()
- Add `gpu_ids` and `multi_gpu` flags to eval config


PS: In the future we should save distributed pretrained models with `torch.save(model.module.state_dict(), PATH)`, this makes the state_dict transparent to the training device. You can then load it into a DataParallel model with `model.module.load_state_dict()` and a regular model with `model.load_state_dict()`. There's no need to manipulate the dictionary keys.