### PR TITLE
Fix issues in preparing the MJFF-LR dataset

### DIFF
--- a/conf/data/ldopa_10s.yaml
+++ b/conf/data/ldopa_10s.yaml
@@ -1,0 +1,13 @@
+data_root: /data/ldopa/prepared
+X_path: "${data.data_root}/X.npy"
+Y_path:  "${data.data_root}/Y.npy"
+PID_path:  "${data.data_root}/pid.npy"
+sample_rate: 30
+task_type: 'classify'
+output_size: 12
+batch_size: 1000
+held_one_subject_out: false
+weighted_loss_fn: true
+dataset_name: 'ldopa'
+subject_count: -1
+ratio2keep: 1

--- a/data_parsing/ldopa.py
+++ b/data_parsing/ldopa.py
@@ -213,7 +213,7 @@ def build_participant_acc_data(subject, datadir, outdir):
         ]
         subjectFile = pd.concat(dataFiles).dropna().drop_duplicates()
         subjectFile = subjectFile / constants.g
-        subjectFile.index.name = "timestamp"
+        subjectFile.index.name = "time"
         subjectFile.rename(
             columns={
                 "GENEActiv_X": "x",
@@ -400,7 +400,7 @@ def download_ldopa(
 
 
 def load_data(
-    datafile, sample_rate=100, index_col="timestamp", annot_type="int"
+    datafile, sample_rate=100, index_col="time", annot_type="int"
 ):
     if ".parquet" in datafile:
         data = pd.read_parquet(datafile)


### PR DESCRIPTION
Addressing issues raised: #23 and #24 

Firstly, acceleration data prepared now has index column "time" instead of "timestamp".
(This has been tested locally but cannot be displayed here due to data privacy).

Second, a config file for reading this data is now supplied. This is found at "conf/data/ldopa_10s.yaml".
